### PR TITLE
Fix react child error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "[typescriptreact]": {
       "editor.formatOnSave": true
     },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "typescript.tsdk": "node_modules/typescript/lib",
     "eslint.validate": [
       "javascript",

--- a/pg-server/types.ts
+++ b/pg-server/types.ts
@@ -34,7 +34,7 @@ export type ProductPayload = Omit<Product, 'id' | 'createdAt'>;
 
 export type Message = {
   id: string;
-  text: string[];
+  text: (string | Record<string, unknown>)[];
   isNew: boolean;
   isAnswered: boolean;
   createdAt: Date;

--- a/src/containers/AdminMain/AdminMain.tsx
+++ b/src/containers/AdminMain/AdminMain.tsx
@@ -185,18 +185,14 @@ const AdminMain = () => {
                     >
                       <Table.Cell collapsing>{moment(message.createdAt).format('L LT')}</Table.Cell>
                       <Table.Cell>
-                        {message.text.map((paragraph, index) => {
-                          if (typeof paragraph !== 'string') {
-                            return (
-                              // eslint-disable-next-line react/no-array-index-key
-                              <p key={`message-paragraph-${index}`}>[falha ao mostrar mensagem]</p>
-                            );
-                          }
-                          return (
-                            // eslint-disable-next-line react/no-array-index-key
-                            <p key={`message-paragraph-${index}`}>{paragraph}</p>
-                          );
-                        })}
+                        {message.text.map((paragraph, index) => (
+                          // eslint-disable-next-line react/no-array-index-key
+                          <p key={`message-paragraph-${index}`}>
+                            {typeof paragraph === 'string'
+                              ? paragraph
+                              : '[falha ao mostrar mensagem]'}
+                          </p>
+                        ))}
                       </Table.Cell>
                       <Table.Cell collapsing>
                         <Icon

--- a/src/containers/AdminMain/AdminMain.tsx
+++ b/src/containers/AdminMain/AdminMain.tsx
@@ -189,7 +189,7 @@ const AdminMain = () => {
                           if (typeof paragraph !== 'string') {
                             return (
                               // eslint-disable-next-line react/no-array-index-key
-                              <p key={`message-paragraph-${index}`}>[falha ao mosrar mensagem]</p>
+                              <p key={`message-paragraph-${index}`}>[falha ao mostrar mensagem]</p>
                             );
                           }
                           return (

--- a/src/containers/AdminMain/AdminMain.tsx
+++ b/src/containers/AdminMain/AdminMain.tsx
@@ -185,10 +185,18 @@ const AdminMain = () => {
                     >
                       <Table.Cell collapsing>{moment(message.createdAt).format('L LT')}</Table.Cell>
                       <Table.Cell>
-                        {message.text.map((paragraph, index) => (
-                          // eslint-disable-next-line react/no-array-index-key
-                          <p key={`message-paragraph-${index}`}>{paragraph}</p>
-                        ))}
+                        {message.text.map((paragraph, index) => {
+                          if (typeof paragraph !== 'string') {
+                            return (
+                              // eslint-disable-next-line react/no-array-index-key
+                              <p key={`message-paragraph-${index}`}>[falha ao mosrar mensagem]</p>
+                            );
+                          }
+                          return (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <p key={`message-paragraph-${index}`}>{paragraph}</p>
+                          );
+                        })}
                       </Table.Cell>
                       <Table.Cell collapsing>
                         <Icon

--- a/src/containers/ChatWindow/ChatWindow.tsx
+++ b/src/containers/ChatWindow/ChatWindow.tsx
@@ -139,7 +139,11 @@ const ChatWindow = () => {
                     key={`${history.speaker}_${index}`}
                     className={styles.userMsg}
                   >
-                    <div className={styles.bullet}>{history.message}</div>
+                    <div className={styles.bullet}>
+                      {typeof history.message === 'string'
+                        ? history.message
+                        : '[falha ao mostrar mensagem]'}
+                    </div>
                     <div className={styles.iconWrapper}>
                       <Icon name="user" circular inverted color="grey" />
                     </div>


### PR DESCRIPTION
For some reason the chat window caused some messages to go through as an object, causing corrupted rendering. This prevents that error.